### PR TITLE
Optimize `entity.add()`.

### DIFF
--- a/src/ecs/Entity.hx
+++ b/src/ecs/Entity.hx
@@ -134,21 +134,20 @@ abstract Entity(Int) from Int to Int {
 
 		var addComponentsToContainersExprs = [for(i => c in components) {
 			var info = complexTypes[i].getComponentContainerInfo(pos);
-			return info.getAddExpr(macro __entity__, c);
-			// var containerName = (c.typeof().follow().toComplexType()).getComponentContainerInfo().fullName;
-			// return macro @:privateAccess $i{ containerName }.inst().add(__entity__, $c);
+			info.getAddExpr(macro __entity__, c);
 		}];
 
 		var addEntityToRelatedViewsExprs = complexTypes.map(function(ct) {
-			return ct.getViewsOfComponent(pos).followName(pos);
-		}).map(function(viewsOfComponentClassName) {
-			var x = viewsOfComponentClassName.asTypeIdent(Context.currentPos());
-			return macro @:privateAccess $x.inst().addIfMatched(__entity__);
+			var viewName = ct.getViewsOfComponent(pos).followName(pos);
+			var view = viewName.asTypeIdent(Context.currentPos());
+			return macro @:privateAccess $view.inst().addIfMatched(__entity__);
 		});
 
-		var body = [].concat(addComponentsToContainersExprs).concat([
-			macro if (__entity__.isActive()) $b{ addEntityToRelatedViewsExprs }
-		]).concat([macro return __entity__]);
+		var body = macro {
+			$b{ addComponentsToContainersExprs };
+			if (__entity__.isActive()) $b{ addEntityToRelatedViewsExprs };
+			return __entity__;
+		};
 
 		var ret = macro #if (haxe_ver >= 4) inline #end (function(__entity__:ecs.Entity) $b{body})($self);
 

--- a/src/ecs/core/macro/ViewsOfComponentBuilder.hx
+++ b/src/ecs/core/macro/ViewsOfComponentBuilder.hx
@@ -51,8 +51,16 @@ class ViewsOfComponentBuilder {
 				public inline function addRelatedView(v:ecs.core.AbstractView) {
 					views.push(v);
 				}
+				
+				public inline function addIfMatched(id:Int) {
+					for (v in views) {
+						if (v.isActive()) {
+							@:privateAccess v.addIfMatched(id);
+						}
+					}
+				}
 
-				public inline function removeIfMatched(id:Int) {
+				public inline function removeIfExists(id:Int) {
 					for (v in views) {
 						if (v.isActive()) { // This is likely a bug - Needs to be removed even if not active
 							@:privateAccess v.removeIfExists(id);


### PR DESCRIPTION
Instead of attempting to add an entity to ALL views, it's best to check only views of the newly-added component. So if you add a `String` component, the function will call `ViewsOfComponentString.inst().addIfMatched()` instead of iterating through `Workflow.views`.

Interestingly, `entity.remove()` was already optimized this way, so I assume this was an oversight.