### PR TITLE
Use pattern matching to simplify `switch` blocks.

### DIFF
--- a/src/ecs/core/macro/ComponentBuilder.hx
+++ b/src/ecs/core/macro/ComponentBuilder.hx
@@ -70,16 +70,19 @@ class StorageInfo {
 	static function getPooled(mm:MetaMap) {
 		var bb = mm.get(":build");
 
-		if (bb != null) {
-			for (b in bb) {
-				switch (b[0].expr) {
-					case ECall({ expr: EField(fe, _) }, _)
-						if (fe.toString() == "ecs.core.macro.PoolBuilder"):
-						return true;
-					default:
-				}
+		if (bb == null) {
+			return false;
+		}
+		
+		for (b in bb) {
+			switch (b[0].expr) {
+				case ECall(_.expr => EField(fe, _), _)
+					if (fe.toString() == "ecs.core.macro.PoolBuilder"):
+					return true;
+				default:
 			}
 		}
+		
 		return false;
 	}
 
@@ -201,7 +204,7 @@ class StorageInfo {
 						if (meta.has(":ecs_remove")):
 						var needsEntity = false;
 						for (a in tfunc.args) {
-							if (a.v.t.toComplexType().toString() == (macro:ecs.Entity).toString()) {
+							if (a.v.t.toComplexType().toString() == "ecs.Entity") {
 								needsEntity = true;
 								break;
 							}

--- a/src/ecs/core/macro/PoolBuilder.hx
+++ b/src/ecs/core/macro/PoolBuilder.hx
@@ -24,14 +24,10 @@ class PoolBuilder {
 		var lt = Context.getLocalType().follow();
 		var ct = lt.toComplexType();
 		switch (lt) {
-			case TInst(t, params):
-				switch (t.get().kind) {
-					case KAbstractImpl(a):
-						if (a.get().params.length > 0)
-							throw 'Pools do not support abstract types with parameters on ${ct.toString()}';
-						ct = a.get().name.asComplexType();
-					default:
-				}
+			case TInst(_.get().kind => KAbstractImpl(a), _):
+				if (a.get().params.length > 0)
+					throw 'Pools do not support abstract types with parameters on ${ct.toString()}';
+				ct = a.get().name.asComplexType();
 			default:
 		}
 

--- a/src/ecs/core/macro/SystemBuilder.hx
+++ b/src/ecs/core/macro/SystemBuilder.hx
@@ -182,12 +182,12 @@ public static function build(debug:Bool = false) {
 
 	// prevent wrong override
 	for (field in fields) {
-		switch (field) {
-			case { kind: FFun(_), name: '__update__' }:
+		switch (field.name) {
+			case '__update__':
 				Context.error('Do not override the `__update__` function! Use `@:update` meta instead! More info at README example', field.pos);
-			case { kind: FFun(_), name: '__activate__' }:
+			case '__activate__':
 				Context.error('Do not override the `__activate__` function! `onactivate` can be overridden instead!', field.pos);
-			case { kind: FFun(_), name: '__deactivate__' }:
+			case '__deactivate__':
 				Context.error('Do not override the `__deactivate__` function! `ondeactivate` can be overridden instead!', field.pos);
 			default:
 		}


### PR DESCRIPTION
(Plus various other cleanup.)

I noticed a lot of nested `switch` blocks that really don't need to be that way. I didn't test this (I don't care to install dependencies like tink_macro), but it should all be equivalent.